### PR TITLE
email: Fix content type and smtp

### DIFF
--- a/lib/email.rs
+++ b/lib/email.rs
@@ -30,9 +30,15 @@ impl Report {
 
         command
             .arg("-s")
-            .arg(format!("{}\r\nContent-Type: text/html", header))
+            .arg(header)
+            .arg("-M")
+            .arg("text/html")
             .arg("-S")
-            .arg(format!("smtp={}", config.smtp()))
+            .arg("v15-compat=yes")
+            .arg("-S")
+            .arg("smtp-auth=none")
+            .arg("-S")
+            .arg(format!("mta=smtp://{}", config.smtp()))
             .arg("-S")
             .arg(format!("replyto={}", config.reply_to()))
             .arg("-r")


### PR DESCRIPTION
The newer mailx doesn't proccess the subject trick which was setting Content-Type. Pass the type via -M option, at the same time fix the warning reported by s-nail about unsupported smtp option:

s-nail: Warning: variable superseded or obsoleted: smtp
s-nail: Obsoletion warning: please do not use *smtp*, instead assign a smtp:// URL to *mta*!
s-nail: Obsoletion warning: Use of old-style credentials, which will vanish in v15!