### PR TITLE
deploy: Make sure the Libvirt is using modular architecture

### DIFF
--- a/vm/vm.xml
+++ b/vm/vm.xml
@@ -29,7 +29,6 @@
             <mac address="52:00:00:00:00:@MAC_SUFFIX@"/>
             <source network="ovn-ci-isolated"/>
             <model type="virtio"/>
-            <driver name="vhost" queues="2"/>
         </interface>
         <channel type='unix'>
             <source mode='bind'/>


### PR DESCRIPTION
The modular architecture is the prefered way since Fedora 35. Use modular instead of monolithic as monolithic might be removed in the future.