### PR TITLE
vm: Add workaround for running podman in virt-customize

### DIFF
--- a/lib/vm/base.rs
+++ b/lib/vm/base.rs
@@ -221,7 +221,7 @@ impl<'a> Vm<'a> {
     }
 }
 
-impl<'a> Drop for Vm<'a> {
+impl Drop for Vm<'_> {
     fn drop(&mut self) {
         self.destroy();
     }

--- a/lib/vm/base.rs
+++ b/lib/vm/base.rs
@@ -148,6 +148,10 @@ impl<'a> Vm<'a> {
 
         if let Some(image_name) = self.config.image_name() {
             command
+                .arg("--delete")
+                .arg("/run/containers/storage")
+                .arg("--delete")
+                .arg("/run/libpod")
                 .arg("--run-command")
                 .arg(format!("podman pull {}", image_name))
                 .arg("--run-command")


### PR DESCRIPTION
For some reason in Fedora 40 onwards the Podman fails with the following error:

Error: current system boot ID differs from cached boot ID; an unhandled reboot has occurred. Please delete directories "/run/containers/storage" and "/run/libpod" and re-run Podman

Remove the suggested directories which allows us to run podman inside virt-customize again.