### PR TITLE
config: Make the timeout optional.

### DIFF
--- a/lib/config.rs
+++ b/lib/config.rs
@@ -69,8 +69,8 @@ impl Configuration {
         self.cli_report_binary.as_deref()
     }
 
-    pub fn timeout(&self) -> &str {
-        self.timeout.as_deref().unwrap_or("0")
+    pub fn timeout(&self) -> Option<&str> {
+        self.timeout.as_deref()
     }
 
     pub fn git(&self) -> &Git {

--- a/lib/runner.rs
+++ b/lib/runner.rs
@@ -70,7 +70,7 @@ impl Runner<New> {
         index: usize,
         memory: u32,
         jobs: usize,
-        timeout: &str,
+        timeout: Option<&str>,
         suite: &Suite,
         log_path: &Path,
     ) -> Self {
@@ -89,8 +89,11 @@ impl Runner<New> {
             .arg("--ovs-path=/workspace/ovs")
             .arg(format!("--jobs={jobs}"))
             .arg("--archive-logs")
-            .arg(format!("--timeout={timeout}"))
             .envs(suite.envs());
+
+        if let Some(timeout_str) = timeout {
+            command.arg(format!("--timeout={timeout_str}"));
+        }
 
         let vm = RunnerVm::new(index, memory, jobs, log_path.to_string_lossy());
 


### PR DESCRIPTION
The timeout is not supported in older OVN branches. Make sure it's skipped when not configured.